### PR TITLE
Add BTC25 token (BEP20)

### DIFF
--- a/blockchains/smartchain/assets/blockchains/smartchain/assets/0x888E3B40CB19389DD93A8E0C98136B6C767C7CB0/info.json
+++ b/blockchains/smartchain/assets/blockchains/smartchain/assets/0x888E3B40CB19389DD93A8E0C98136B6C767C7CB0/info.json
@@ -1,0 +1,11 @@
+{
+  "name": "BTC25",
+  "symbol": "BTC25",
+  "type": "BEP20",
+  "decimals": 18,
+  "description": "BTC25 is a meme token created by a Bitcoin mining company. It’s just a fun token with no guaranteed value or borders. Issued on the BEP-20 standard. We will strive to make it a star project on Binance.",
+  "website": "https://app.galxe.com/quest/BTC25",
+  "explorer": "https://bscscan.com/token/0x888E3B40CB19389DD93A8E0C98136B6C767C7CB0",
+  "status": "active",
+  "id": "0x888E3B40CB19389DD93A8E0C98136B6C767C7CB0"
+}


### PR DESCRIPTION
Adding BTC25 token information and logo to Trust Wallet assets repository.

Contract: 0x888e3B40cB19389DD93a8e0c98136B6c767C7cB0  
Website: https://app.galxe.com/quest/BTC25  

BTC25 is a meme token created by a Bitcoin mining company.  
It’s a fun community token with no guaranteed value and no borders, based on the BEP-20 standard.  
We aim to make BTC25 a star project on Binance.
